### PR TITLE
Update dspace_mets.xml

### DIFF
--- a/src/main/resources/formats/dspace_mets.xml
+++ b/src/main/resources/formats/dspace_mets.xml
@@ -63,9 +63,9 @@
             <!-- Keywords (dc.subject) -->
             <epdcx:statement
                 epdcx:propertyURI="http://purl.org/dc/elements/1.1/subject"
-                th:each="fv : ${METS_FIELD_VALUES}"
-                th:if="${fv.fieldPredicate.element == 'keywords'}">
-              <epdcx:valueString th:text="${fv.value}" />
+              <epdcx:valueString 
+                th:each="kw : ${SUBMISSION.getKeywordFieldValues()}"
+                th:text="${kw.value}" />
             </epdcx:statement>
 
             <!-- Subject (dc.subject) -->


### PR DESCRIPTION
Looking at the java formatter for DSpaceMets, it's likely it isn't pulling metadata keys that do not meet: dc, thesis, or local. This will directly call from the submission fields, instead of just the whitelist the formatter allows.